### PR TITLE
switch validation logic to python module ipaddress

### DIFF
--- a/ipexdbl.py
+++ b/ipexdbl.py
@@ -54,7 +54,10 @@ def save_ips(urls, filename):
  
     with open(filename, 'w') as file:
         for ip in sorted(unique_ips, key=ipaddress.get_mixed_type_key):  # Sort IPs for better readability
-            file.write(format(ip) + '\n')
+            if ip.num_addresses == 1:
+                file.write(format(ip.hosts()[0]) + '\n')
+            else:
+                file.write(format(ip) + '\n')
     print(f"Saved {len(unique_ips)} unique IP addresses to {filename}")
   
     # Calculate and display the difference in IP counts  


### PR DESCRIPTION
This has the following pros:
1. Uses the built in module which does a better job of validating ip address and networks
2. Enables ipv6 addresses and networks
3. Sorting of IP address is now correct

but has the con:
file size of the blacklist is bigger, since all ip addresses are handled as a network, individual ip addresses are stored with a /32 or /128 netmask

Also since the sorting has changes you cannot directly compare with older blacklist files, but after 2 runs that is no longer a problem.